### PR TITLE
Making Fritter Kotlin Friendly (and Java static final too)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
 jdk:
-  - oraclejdk7
   - oraclejdk8
-  - openjdk7
+  - openjdk8
 
 after_success:
   - ./gradlew cobertura coveralls

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ public class Person {
     String description;
     Category category;
     String image;
+    final String country; // fritter will populate this field
+    @FritterIgnoreField
+    String memberId; // fritter will leave this field alone
+    
+    static String CATEGORY; // fritter will populate this field
+    static String TAG = 1; // fritter won't touch static field with a non-null value
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'one.equinox.fritterfactory'
-version '0.0.2'
+version '0.0.4'
 
 apply plugin: 'java'
 apply plugin: 'com.novoda.bintray-release'

--- a/src/main/java/one/equinox/fritterfactory/annotation/FritterIgnoreField.java
+++ b/src/main/java/one/equinox/fritterfactory/annotation/FritterIgnoreField.java
@@ -1,0 +1,14 @@
+package one.equinox.fritterfactory.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a field that should be ignored by Fritter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface FritterIgnoreField {
+}

--- a/src/test/java/one/equinox/fritterfactory/test/FritterFactoryTest.java
+++ b/src/test/java/one/equinox/fritterfactory/test/FritterFactoryTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class FritterFactoryTest {
     FritterFactory fritterFactory = new FritterFactory();
@@ -21,7 +22,19 @@ public class FritterFactoryTest {
         assertNotNull(model.getStringVal());
         assertNotNull(model.getIntegerVal());
         assertNotEquals(model.getIntVal(),0);
+        assertNotNull(model.getFinalStringVal());
 
+        assertNotNull(MyModel.sNoVal);
+
+        // Make sure that non-null (or final) statics are not overwritten
+        assertEquals(MyModel.sVal, "My String");
+        assertEquals(MyModel.fVal, "My final String");
+        assertNull(MyModel.fNullVal);
+
+        // Assert ignored fields are still null
+        assertNull(model.getIgnoredStringVal());
+        assertNull(model.getFinalIgnoredString());
+        assertNull(MyModel.sIgnoredString);
     }
 
     @Test
@@ -32,6 +45,7 @@ public class FritterFactoryTest {
             assertNotNull(model.getStringVal());
             assertNotNull(model.getIntegerVal());
             assertNotEquals(model.getIntVal(), 0);
+            assertNotNull(model.getFinalStringVal());
         }
     }
 
@@ -43,7 +57,6 @@ public class FritterFactoryTest {
         assertNotEquals(model.getStringVal(), model2.getStringVal());
         assertNotEquals(model.getIntegerVal(), model2.getIntegerVal());
         assertNotEquals(model.getIntVal(), model2.getIntVal());
+        assertNotEquals(model.getFinalStringVal(), model2.getFinalStringVal());
     }
-
-
 }

--- a/src/test/java/one/equinox/fritterfactory/test/model/MyModel.java
+++ b/src/test/java/one/equinox/fritterfactory/test/model/MyModel.java
@@ -1,9 +1,22 @@
 package one.equinox.fritterfactory.test.model;
 
+import one.equinox.fritterfactory.annotation.FritterIgnoreField;
 import one.equinox.symbols.Symbolize;
 
 @Symbolize
-public class MyModel{
+public class MyModel {
+    @FritterIgnoreField
+    String ignoredStringVal;
+
+    @FritterIgnoreField
+    final String finalIgnoredString;
+
+    MyModel() {
+        finalStringVal = null;
+        finalIgnoredString = null;
+    }
+
+    final String finalStringVal;
     String stringVal;
     int intVal;
     Integer integerVal;
@@ -16,4 +29,17 @@ public class MyModel{
     public Integer getIntegerVal() {
         return integerVal;
     }
+    public String getIgnoredStringVal() { return ignoredStringVal; }
+    public String getFinalIgnoredString() { return finalIgnoredString; }
+    public String getFinalStringVal() { return finalStringVal; }
+
+    public static String sNoVal;
+
+    @FritterIgnoreField
+    public static String sIgnoredString;
+
+    public static String sVal = "My String";
+    public static final String fVal = "My final String";
+
+    public static final String fNullVal = null;
 }


### PR DESCRIPTION
In an attempt to let Fritter leave Kotlin Companion `vars` and `lets` untouched I've added some features that might be helpful to other as well.

Added:
- @FritterIgnoreField annotation to allow for skipping a Field
- Fritter doesn't touch static final fields anymore (which would result in exceptions thrown by Fritter before)
- Fritter doesn't touch static non-null value fields anymore (as this is my Companion use-case)